### PR TITLE
ps needs the -p flag used explicitly in OpenBSD.

### DIFF
--- a/lib/snorby/worker.rb
+++ b/lib/snorby/worker.rb
@@ -45,7 +45,7 @@ module Snorby
     end
 
     def self.process
-      return Snorby::Process.new(`ps aux -p #{Worker.pid} |grep delayed_job |grep -v grep`.chomp.strip)
+      return Snorby::Process.new(`ps -o ruser,pid,%cpu,%mem,vsize,rss,tt,stat,start,etime,command -p #{Worker.pid} |grep delayed_job |grep -v grep`.chomp.strip)
     end
 
     def self.pid


### PR DESCRIPTION
On OpenBSD 4.9 ps with aux needs the -p flag or it thinks the PID is a file.
