### PR TITLE
Deprecation Warning Fix.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,5 +3,6 @@
 
 require File.expand_path('../config/application', __FILE__)
 require 'rake'
+include Rake::DSL if defined?(Rake::DSL)
 
 Snorby::Application.load_tasks


### PR DESCRIPTION
Global access to Rake DSL methods is deprecated. Included Rake DSL method.
