### PR TITLE
Updated fix for issue 152

### DIFF
--- a/app/views/page/search.html.erb
+++ b/app/views/page/search.html.erb
@@ -58,7 +58,7 @@
 			
 			<div class='grid_4 alpha'>
 				<%= label_tag 'Select Classification' %><br />
-				<%= select_tag '[search][classification_id]', dropdown_select_tag(Classification.all, :id, true, ["<option value=''>Unclassified</option>"]), :class => 'add_chosen' %>
+				<%= select_tag '[search][classification_id]', dropdown_select_tag(Classification.all, :id, true, ["<option value='nil'>Unclassified</option>"]), :class => 'add_chosen' %>
 			</div>
 			
 			<div class='grid_4 alpha'>


### PR DESCRIPTION
The previous applied fix for issue 152 doesn't fix the issue. By changing the value to 'nil' it will return results for events without a classification.
