### PR TITLE
Add Timezones to Snorby

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,10 +7,11 @@ module ApplicationHelper
       # time.strftime('%A, %b %d, %Y at %l:%M:%S %p')
     # end
 
+    time_zone = Time.parse(DateTime.now.to_s).strftime('%Z')
     time_string = '%A, %b %d, %Y at %l:%M:%S %p'
     time_string = '%a, %b %d, %y at %I:%M:%S %p' if short
 
-    time.strftime(time_string)
+    "#{time.strftime(time_string)} #{time_zone}"
   end
 
   def geoip?

--- a/app/views/page/dashboard.html.erb
+++ b/app/views/page/dashboard.html.erb
@@ -64,7 +64,7 @@
 
           <li class='right last-cache-time'>
             <% if @last_cache.present? %>
-            <i>Updated: <%= @last_cache.strftime('%D %l:%M:%S %p') %></i>
+            <i>Updated: <%= @last_cache.strftime('%D %l:%M:%S %p %Z') %></i>
             <% end %>
           </li>
 


### PR DESCRIPTION
This pull requests adds the box's local timezone to al time's display within the application. In order to avoid confusion ensure your sensors are sending in the same timezone as the Snorby box as Snort's db schema does not allow you to set a timezone agnostic time.
