### PR TITLE
fixed typo in sensor controller before_filter

### DIFF
--- a/app/controllers/sensors_controller.rb
+++ b/app/controllers/sensors_controller.rb
@@ -1,6 +1,6 @@
 class SensorsController < ApplicationController
 
-  before_filter :require_administrative_privileges, :except => [:index, :destory]
+  before_filter :require_administrative_privileges, :except => [:index, :destroy]
   
   def index
     @sensors ||= Sensor.all.page(params[:page].to_i, :per_page => @current_user.per_page_count, :order => [:sid.asc])


### PR DESCRIPTION
The before_filter had a typo for the :destroy method.
