### PR TITLE
Fix for https URLs in email notifications

### DIFF
--- a/config/snorby_config.yml.example
+++ b/config/snorby_config.yml.example
@@ -9,7 +9,6 @@ production:
   domain: 'demo.snorby.org'
   wkhtmltopdf: /usr/local/bin/wkhtmltopdf
   ssl: false
-  https: true
   mailer_sender: 'snorby@snorby.org'
   geoip_uri: "http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz"
   rules:
@@ -23,7 +22,6 @@ development:
   domain: localhost:3000
   wkhtmltopdf: /Users/mephux/.rvm/gems/ruby-1.9.2-p0/bin/wkhtmltopdf
   ssl: false
-  https: false
   mailer_sender: 'snorby@snorby.org'
   geoip_uri: "http://geolite.maxmind.com/download/geoip/database/GeoLiteCountry/GeoIP.dat.gz"
   rules: 


### PR DESCRIPTION
Uses a flag in snorby_config.yml to fix the URL sent out via email notifications if https is desired.  
