### PR TITLE
Added ability to set timezone preferences for search

### DIFF
--- a/config/initializers/app_config.rb
+++ b/config/initializers/app_config.rb
@@ -1,0 +1,5 @@
+# Gives libraries, controllers, models, and views access to the
+# settings set in config/snorby_config.yml
+# http://stackoverflow.com/questions/592554/best-way-to-create-custom-config-options-for-my-rails-app
+
+APP_CONFIG = YAML.load_file(Rails.root.join('config', 'snorby_config.yml'))[Rails.env]

--- a/config/snorby_config.yml.example
+++ b/config/snorby_config.yml.example
@@ -14,6 +14,10 @@ production:
   rules:
     - ""
   authentication_mode: database
+  # If timezone_search is undefined or false, searching based on time will
+  # use UTC times (historical behavior). If timezone_search is true
+  # searching will use local time.
+  timezone_search: true
   # uncomment to set time zone to time zone of box from /usr/share/zoneinfo, e.g. "America/Cancun"
   # time_zone: 'UTC'
 

--- a/lib/snorby/search.rb
+++ b/lib/snorby/search.rb
@@ -373,7 +373,10 @@ module Snorby
               unless [:isnull, :notnull].include?(operator)
 
                 if [:start_time, :end_time].include?(column)
-                  value = Time.zone.parse(value).utc.strftime('%Y-%m-%d %H:%M:%S') 
+                  # If timezone_search exists ands is set to true
+                  # in snorby_config.yml set the search with the local time.
+                  # Otherwise (default) search with UTC
+		  value = APP_CONFIG['timezone_search'] ?  Time.zone.parse(value).strftime('%Y-%m-%d %H:%M:%S') : Time.zone.parse(value).utc.strftime('%Y-%m-%d %H:%M:%S')
                 end
 
                 if column == :signature_name
@@ -425,7 +428,10 @@ module Snorby
             unless [:isnull, :notnull].include?(operator)
 
               if [:start_time, :end_time].include?(column)
-                value = Time.zone.parse(value).utc.strftime('%Y-%m-%d %H:%M:%S') 
+	  	# If timezone_search exists ands is set to true
+                # in snorby_config.yml set the search with the local time.
+                # Otherwise (default) search with UTC
+                value = APP_CONFIG['timezone_search'] ?  Time.zone.parse(value).strftime('%Y-%m-%d %H:%M:%S') : Time.zone.parse(value).utc.strftime('%Y-%m-%d %H:%M:%S')
               end
 
               if column == :signature_name


### PR DESCRIPTION
Setting timezone_search: true in snorby_config.yml makes search.rb
Obey local time settings. Setting it to false or leaving it undefined
reverts to UTC time (historical behavior).
In response to #301
