### PR TITLE
Feature Request #273 - Can now search using a range

### DIFF
--- a/lib/snorby/search.rb
+++ b/lib/snorby/search.rb
@@ -492,6 +492,14 @@ module Snorby
             {
               :id => :is_not,
               :value => "is not"
+            },
+            {
+              :id => :gte,
+              :value => "range start"
+            },
+            {
+              :id => :lte,
+              :value => "range end"
             }
           ],
           :datetime => [


### PR DESCRIPTION
Added the feature to search for a range of IPs or ports. The list of operators to select from is now [is, is not, range start, range end]
To search a range, set the first search field operator to 'range start' and another one to 'range end' using the same query term for both.
