### PR TITLE
fixing Gemfile <-> Gemfile.lock disagreement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: http://github.com/Snorby/delayed_job_data_mapper.git
+  remote: https://github.com/Snorby/delayed_job_data_mapper.git
   revision: 6f1c4a8c3ad62e4ef6baafec9a2a9914d0643085
   specs:
     delayed_job_data_mapper (1.0.0.rc)
@@ -9,7 +9,7 @@ GIT
       dm-observer
 
 GIT
-  remote: http://github.com/Snorby/snorby_cas_authenticatable.git
+  remote: https://github.com/Snorby/snorby_cas_authenticatable.git
   revision: 281a58b363683b624ec92b8ea2929f3c93cdf30d
   specs:
     devise_cas_authenticatable (1.0.0.alpha10)
@@ -18,7 +18,7 @@ GIT
       rubycas-client (>= 2.2.1)
 
 GIT
-  remote: http://github.com/mephux/ezprint.git
+  remote: https://github.com/mephux/ezprint.git
   revision: c231df760dae8a2d4bc906888285c6d314de4cf6
   branch: rails3
   specs:


### PR DESCRIPTION
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.

If this is a development machine, remove the Gemfile freeze
by running `bundle install --no-deployment`.

You have added to the Gemfile:
- source: https://github.com/Snorby/delayed_job_data_mapper.git (at master)
- source: https://github.com/mephux/ezprint.git (at rails3)
- source: https://github.com/Snorby/snorby_cas_authenticatable.git (at master)

You have deleted from the Gemfile:
- source: http://github.com/Snorby/delayed_job_data_mapper.git (at master)
- source: http://github.com/Snorby/snorby_cas_authenticatable.git (at master)
- source: http://github.com/mephux/ezprint.git (at rails3)

You have changed in the Gemfile:
- devise_cas_authenticatable from `https://github.com/Snorby/snorby_cas_authenticatable.git (at master)` to `no specified source`
- ezprint from `https://github.com/mephux/ezprint.git (at rails3)` to `no specified source`
- delayed_job_data_mapper from `https://github.com/Snorby/delayed_job_data_mapper.git (at master)` to `no specified source`
