### PR TITLE
Fixing uninitialized constant Rake::DSL issue

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,6 +2,7 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
+require 'rake/dsl_definition'
 require 'rake'
 include Rake::DSL if defined?(Rake::DSL)
 


### PR DESCRIPTION
Reference: http://stackoverflow.com/questions/6181312/how-to-fix-the-uninitialized-constant-rakedsl-problem-on-heroku

Error:

```
rake snorby:setup
(in /opt/snorby)
No time_zone specified in snorby_config.yml; detected time_zone: US/Central
rake aborted!
uninitialized constant Rake::DSL
```
