### PR TITLE
changed Worker.reset_cache to Jobs.reset_cache in snorby.rake

### DIFF
--- a/lib/tasks/snorby.rake
+++ b/lib/tasks/snorby.rake
@@ -137,7 +137,7 @@ namespace :snorby do
     Signature.update!(:events_count => 0)
 
     puts 'This could take awhile. Please wait while the Snorby cache is rebuilt.'
-    Snorby::Worker.reset_cache(:all, true)
+    Snorby::Jobs.reset_cache(:all, true)
   end
   
   desc 'Hard Reset - Rebuild Snorby Database'


### PR DESCRIPTION
There is no clear_cache in Worker module. IMO it was here by mistake.
