### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Snorby is a ruby on rails web application for network security monitoring that i
 ## Requirements
 
 * Snort
-* Ruby >= 1.9.2
+* Ruby >= 1.9.2, <2.x.x
 * Rails >= 3.0.0
 
 ## Install


### PR DESCRIPTION
installing snorby on OS X with ruby 2 won't work:

```
$ ruby -v
ruby 2.0.0p481 (2014-05-08 revision 45883) [universal.x86_64-darwin14]
$ sw_vers 
ProductName:    Mac OS X
ProductVersion: 10.10.4
BuildVersion:   14E46
```
