### PR TITLE
Add tips to fix "already initialized constant PDF"

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Snorby is a ruby on rails web application for network security monitoring that i
 
 	`rake snorby:setup`
 	
+	* NOTE: If you get warning such as "already initialized constant PDF", you can fix it by running these commands :
+
+	```
+	sed -i 's/\(^.*\)\(Mime::Type.register.*application\/pdf.*$\)/\1if Mime::Type.lookup_by_extension(:pdf) != "application\/pdf"\n\1  \2\n\1end/' vendor/cache/ruby/*.*.*/bundler/gems/ezprint-*/lib/ezprint/railtie.rb
+	sed -i 's/\(^.*\)\(Mime::Type.register.*application\/pdf.*$\)/\1if Mime::Type.lookup_by_extension(:pdf) != "application\/pdf"\n\1  \2\n\1end/' vendor/cache/ruby/*.*.*/gems/actionpack-*/lib/action_dispatch/http/mime_types.rb
+	sed -i 's/\(^.*\)\(Mime::Type.register.*application\/pdf.*$\)/\1if Mime::Type.lookup_by_extension(:pdf) != "application\/pdf"\n\1  \2\n\1end/' vendor/cache/ruby/*.*.*/gems/railties-*/guides/source/action_controller_overview.textile
+	```
+
 * Edit The Snorby Configuration File
 
 	`config/snorby_config.yml`


### PR DESCRIPTION
It seems that "application/pdf" mime type is already a registered one in Rails.