### PR TITLE
Make worker run on Solaris / Illumos

### DIFF
--- a/lib/snorby/worker.rb
+++ b/lib/snorby/worker.rb
@@ -28,7 +28,11 @@ module Snorby
 
     def self.process
       if Worker.pid
-        Snorby::Process.new(`ps -o ruser,pid,%cpu,%mem,vsize,rss,tt,stat,start,etime,command -p #{Worker.pid} |grep delayed_job |grep -v grep`.chomp.strip)
+        if RUBY_PLATFORM =~ /solaris/ then
+          Snorby::Process.new(`ps -o ruser,pid,pcpu,pmem,vsz,rss,tty,s,stime,etime,args -p #{Worker.pid} |grep delayed_job |grep -v grep`.chomp.strip)
+        else
+          Snorby::Process.new(`ps -o ruser,pid,%cpu,%mem,vsize,rss,tt,stat,start,etime,command -p #{Worker.pid} |grep delayed_job |grep -v grep`.chomp.strip)
+        end
       end
     end
 


### PR DESCRIPTION
Solaris (and Illumos, by extension) uses different format flags for ps(1). This fixes it based on RUBY_PLATFORM. It may enable it to work on other SysV UNIXes (AIX & HPUX) but I'm not confident of that and have no way of testing so I left the check to be explicitly Solaris