### PR TITLE
Fix error running snorby:soft_reset task.

### DIFF
--- a/lib/tasks/snorby.rake
+++ b/lib/tasks/snorby.rake
@@ -137,7 +137,7 @@ namespace :snorby do
     Signature.update!(:events_count => 0)
 
     puts 'This could take awhile. Please wait while the Snorby cache is rebuilt.'
-    Snorby::Worker.reset_cache(:all, true)
+    Snorby::Jobs.reset_cache(:all, true)
   end
   
   desc 'Hard Reset - Rebuild Snorby Database'


### PR DESCRIPTION
When the task snorby:soft_reset is executed, the next error is showed:

```
** Invoke snorby:soft_reset (first_time)
** Invoke environment (first_time)
** Execute environment
** Execute snorby:soft_reset
Reseting Snorby metrics and counter cache columns
This could take awhile. Please wait while the Snorby cache is rebuilt.
rake aborted!
undefined method `reset_cache' for Snorby::Worker:Class
```